### PR TITLE
add autoMode feature to MaterialTheme

### DIFF
--- a/src/components/MaterialTheme.jsx
+++ b/src/components/MaterialTheme.jsx
@@ -14,8 +14,10 @@ const propTypes = {
   hour: PropTypes.string,
   minute: PropTypes.string,
   focused: PropTypes.bool,
+  autoMode: PropTypes.bool,
   handleHourChange: PropTypes.func,
-  handleMinuteChange: PropTypes.func
+  handleMinuteChange: PropTypes.func,
+  clearFocus: PropTypes.func
 };
 
 const defaultProps = {
@@ -23,8 +25,10 @@ const defaultProps = {
   hour: '00',
   minute: '00',
   focused: false,
+  autoMode: false,
   handleHourChange: () => {},
-  handleMinuteChange: () => {}
+  handleMinuteChange: () => {},
+  clearFocus: () => {}
 };
 
 import PickerDargHandler from './PickerDargHandler';
@@ -34,7 +38,7 @@ class MaterialTheme extends React.Component {
   constructor(props) {
     super(props);
     let pointerRotate = this.resetHourDegree();
-    let {step} = props;
+    let {step, autoMode} = props;
     this.state = {
       step,
       pointerRotate
@@ -71,11 +75,16 @@ class MaterialTheme extends React.Component {
   handleTimeChange(time) {
     time = parseInt(time);
     let {step} = this.state;
-    let {handleHourChange, handleMinuteChange} = this.props;
+    let {handleHourChange, handleMinuteChange, autoMode} = this.props;
     if (step === 0) {
       handleHourChange && handleHourChange(time);
+      autoMode && this.handleStepChange(1);
     } else {
       handleMinuteChange && handleMinuteChange(time);
+      if (autoMode) {
+        this.props.clearFocus();
+        this.setState({step: 0});
+      }
     }
   }
 

--- a/src/components/TimePicker.jsx
+++ b/src/components/TimePicker.jsx
@@ -15,6 +15,7 @@ import {
 const propTypes = {
   defaultTime: PropTypes.string,
   focused: PropTypes.bool,
+  autoMode: PropTypes.bool,
   placeholder: PropTypes.string,
   colorPalette: PropTypes.string,
   theme: PropTypes.string,
@@ -32,6 +33,7 @@ const propTypes = {
 const defaultProps = {
   defaultTime: moment().format("HH:mm"),
   focused: false,
+  autoMode: false,
   placeholder: '',
   colorPalette: "light",
   timeMode: "24",
@@ -46,7 +48,7 @@ const defaultProps = {
 class TimePicker extends React.Component {
   constructor(props) {
     super(props);
-    let {defaultTime, focused, timeMode} = props;
+    let {defaultTime, focused, timeMode, autoMode} = props;
     let [hour, minute, timeInterval] = initialTime(defaultTime, getValidateTimeMode(timeMode));
     this.state = {
       hour,
@@ -113,13 +115,16 @@ class TimePicker extends React.Component {
 
   renderMaterialTheme() {
     let {hour, minute, focused} = this.state;
+    let {autoMode} = this.props;
     return (
       <MaterialTheme
         hour={hour}
         minute={minute}
         focused={focused}
+        autoMode={autoMode}
         handleHourChange={this.handleHourChange}
         handleMinuteChange={this.handleMinuteChange}
+        clearFocus={this.onClearFocus}
       />
     )
   }

--- a/stories/TimePicker.js
+++ b/stories/TimePicker.js
@@ -16,6 +16,11 @@ storiesOf('Default TimePicker', module)
       focused={true}
     />
   ))
+  .add('auto mode', () => (
+    <TimePickerWrapper
+      autoMode={true}
+    />
+  ))
   .add('focused at setup', () => (
     <TimePickerWrapper
       withoutIcon={true}


### PR DESCRIPTION
I called it "autoMode". It moves user to choose moment right after choosing the hour and clears the focus after she chooses the minutes.