### PR TITLE
Increase the phone drag events, optimize the pointer animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### v2.1.0
+
+#### new props
+
+- `phrases`: `React.PropTypes.object`
+- `timezone`: `React.PropTypes.string`
+- `onTimezoneChange`: `React.PropTypes.func`
+
 ### v2.0.0
 
 #### changed props
@@ -12,4 +20,3 @@
 
 - `showTimezone`: `React.PropTypes.bool`, default `false`
 - `timezone`:  `React.PropTypes.string`, default user current local timezone
-

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ timeMode=12
 
 > `React.PropTypes.string`, change user timezone, default user current local timezone.
 
-- trigger`
+- `trigger`
 
 > `React.component`, means a DOM which can control TimePicker Modal "open" or "close" status.
 
@@ -283,8 +283,8 @@ If you don't want to drag the pointer, then you can set `draggable` props to `fa
 - `phrases`
 
 > `React.object`, specify text values to use for specific messages.  By default, phrases will be set from defaults based on language.
-Specify any of the available phrases you wish to override or all of them if your desired language is not yet supported.
-See [language.js](./src/utils/language.js) for default phrases.
+> Specify any of the available phrases you wish to override or all of them if your desired language is not yet supported.
+> See [language.js](./src/utils/language.js) for default phrases.
 
 ```javascript
 <TimePicker
@@ -348,6 +348,12 @@ onTimeChange(time) {
 
 > The callback func when meridiem changed.
 
+- `onTimezoneChange`
+
+`React.PropTypes.func`
+
+> The callback func when timezone changed.
+
 # Article
 
 - [一言不合造轮子--撸一个ReactTimePicker](https://github.com/ecmadao/Coding-Guide/blob/master/Notes/React/ReactJS/Write%20a%20React%20Timepicker%20Component%20hand%20by%20hand.md)
@@ -391,9 +397,8 @@ Thanks to the Airbnb's open source project: [react-dates](https://github.com/air
 # Core Contributers 🎉
 
 - **[carlodicelico](https://github.com/carlodicelico)**
-
+- **[erin-doyle](https://github.com/erin-doyle)**
 - **[thg303](https://github.com/thg303)**
-
 - **[naseeihity](https://github.com/naseeihity)**
 
 # License

--- a/README_CN.md
+++ b/README_CN.md
@@ -281,6 +281,22 @@ timeMode=12
 />
 ```
 
+- `phrases`
+
+> `React.object`，用于自定义一些短语。可以在 [language.js](./src/utils/language.js) 查看所有的默认短语
+
+```javascript
+<TimePicker
+  phrases={{
+    confirm: '确认更改？',
+    cancel: '确认取消？',
+    close: 'DONE',
+    am: '上午',
+    pm: '下午'
+  }}
+/>
+```
+
 ## 回调
 
 - `onFocusChange`
@@ -331,6 +347,12 @@ onTimeChange(time) {
 
 > 当 上、下午改变时触发的回调
 
+- `onTimezoneChange`
+
+`React.PropTypes.func`
+
+> 当时区改变时的回调
+
 # 相关文章
 
 - [一言不合造轮子--撸一个ReactTimePicker](https://github.com/ecmadao/Coding-Guide/blob/master/Notes/React/ReactJS/Write%20a%20React%20Timepicker%20Component%20hand%20by%20hand.md)
@@ -374,6 +396,8 @@ onTimeChange(time) {
 # 核心贡献者 🎉
 
 - **[carlodicelico](https://github.com/carlodicelico)**
+
+- **[erin-doyle](https://github.com/erin-doyle)**
 
 - **[thg303](https://github.com/thg303)**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-times",
   "description": "A react time-picker component, no jquery-rely",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "ecmadao",
   "bugs": {
     "url": "https://github.com/ecmadao/react-times/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-times",
   "description": "A react time-picker component, no jquery-rely",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "ecmadao",
   "bugs": {
     "url": "https://github.com/ecmadao/react-times/issues"

--- a/src/components/MaterialTheme/TwelveHoursMode.jsx
+++ b/src/components/MaterialTheme/TwelveHoursMode.jsx
@@ -190,18 +190,19 @@ class TwelveHoursMode extends React.PureComponent {
             handleTimePointerClick={this.handleMinutePointerClick}
           />
           <PickerDragHandler
+            step={1}
+            rotateState={minuteRotateState}
+            time={parseInt(minute)}
+            minLength={MAX_ABSOLUTE_POSITION}
+            draggable={draggable}
+            handleTimePointerClick={this.handleMinutePointerClick} />
+          <PickerDragHandler
             step={0}
             rotateState={hourRotateState}
             time={parseInt(hour)}
             maxLength={MIN_ABSOLUTE_POSITION}
             draggable={draggable}
             handleTimePointerClick={this.handleHourPointerClick} />
-          <PickerDragHandler
-            step={1}
-            rotateState={minuteRotateState}
-            time={parseInt(minute)}
-            minLength={MAX_ABSOLUTE_POSITION}
-            handleTimePointerClick={this.handleMinutePointerClick} />
         </div>
         {showTimezone
           ? <Timezone

--- a/src/components/Picker/PickerDragHandler.jsx
+++ b/src/components/Picker/PickerDragHandler.jsx
@@ -205,8 +205,8 @@ class PickerDragHandler extends React.PureComponent {
     if (this.state.draging) {
       const {minLength, maxLength} = this.props;
       const pos = darg.mousePosition(e);
-      const dragX = pos.x;
-      const dragY = pos.y;
+      const dragX = pos.x + this.offsetDragCenterX;
+      const dragY = pos.y + this.offsetDragCenterY;
       if (this.originX !== dragX && this.originY !== dragY) {
         const sRad = this.getRadian(dragX, dragY);
         const pointerRotate = sRad * (360 / (2 * Math.PI));


### PR DESCRIPTION
##### 本次更新主要有三个部分：
1. 添加了手机触摸事件，在手机浏览器上也可以正常的拖动指针。
2. 重新计算坐标系，[以指针中心为坐标原点](https://github.com/shianqi/react-times/commit/98dd6651bba386a0b6b8e2cb6408a6d39655bdd0#diff-a58bdac9991bec98e2f21ee90d93cbe9R133)，简化计算。
3. 取消对 `pointerRotate` 度数的限制，使点击表盘或者拖动指针时，指针能够从度数变换更小的方向移动（解决有时候指针移动时候需要转一大圈才移到相应位置）😃
