### PR TITLE
Fix React 15.5 deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
 
 #### new props
 
-- `phrases`: `React.PropTypes.object`
-- `timezone`: `React.PropTypes.string`
-- `onTimezoneChange`: `React.PropTypes.func`
+- `phrases`: `PropTypes.object`
+- `timezone`: `PropTypes.string`
+- `onTimezoneChange`: `PropTypes.func`
 
 ### v2.0.0
 
@@ -23,5 +23,5 @@
 
 #### new props
 
-- `showTimezone`: `React.PropTypes.bool`, default `false`
-- `timezone`:  `React.PropTypes.string`, default user current local timezone
+- `showTimezone`: `PropTypes.bool`, default `false`
+- `timezone`:  `PropTypes.string`, default user current local timezone

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ render() {
 > Initial time, must be a string, with `${hour}:${minute}` format, default now (by using `moment()`):
 
 ```javascript
-// React.PropTypes.string
+// PropTypes.string
 time="11:11"
 time="11:01"
 time="1:01"
@@ -188,7 +188,7 @@ time="1:1"
 > Whether the timepicker pannel is focused or not when it did mount. Default `false`
 
 ```javascript
-// React.PropTypes.bool
+// PropTypes.bool
 focused={false}
 focused={true}
 ```
@@ -198,7 +198,7 @@ focused={true}
 > Whether the timepicker has a svg icon. Default `false`.
 
 ```javascript
-// React.PropTypes.bool
+// PropTypes.bool
 withoutIcon={true}
 ```
 
@@ -207,7 +207,7 @@ withoutIcon={true}
 > The main color palette of picker pannel. Default `light`.
 
 ```javascript
-// React.PropTypes.string
+// PropTypes.string
 colorPalette="dark"
 colorPalette="light"
 ```
@@ -217,7 +217,7 @@ colorPalette="light"
 > Support "12" or "24" hours mode.
 
 ```javascript
-// React.PropTypes.string or React.PropTypes.number
+// PropTypes.string or PropTypes.number
 timeMode="24"
 timeMode=24
 timeMode="12"
@@ -226,15 +226,15 @@ timeMode=12
 
 - `meridiem`
 
-> `React.PropTypes.string`, support "PM" or "AM" for 12 hours mode, default `AM`
+> `PropTypes.string`, support "PM" or "AM" for 12 hours mode, default `AM`
 
 - `showTimezone`
 
-> `React.PropTypes.bool`, whether show user timezone or not, default `false`
+> `PropTypes.bool`, whether show user timezone or not, default `false`
 
 - `timezone`
 
-> `React.PropTypes.string`, change user timezone, default user current local timezone.
+> `PropTypes.string`, change user timezone, default user current local timezone.
 
 - `trigger`
 
@@ -302,13 +302,13 @@ If you don't want to drag the pointer, then you can set `draggable` props to `fa
 
 - `onFocusChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > The callback func when component `focused` state is changed.
 
 - `onHourChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > The callback func when component `hour` state is changed.
 
@@ -320,7 +320,7 @@ onHourChange(hour) {
 
 - `onMinuteChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > The callback func when component `minute` state is changed.
 
@@ -332,7 +332,7 @@ onMinuteChange(minute) {
 
 - `onTimeChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > The callback func when component `hour` or `minute` or `AM/PM` state is changed.
 
@@ -344,13 +344,13 @@ onTimeChange(time) {
 
 - `onMeridiemChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > The callback func when meridiem changed.
 
 - `onTimezoneChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > The callback func when timezone changed.  Receives timezone object as argument with the following properties:
 * city

--- a/README_CN.md
+++ b/README_CN.md
@@ -177,7 +177,7 @@ render() {
 > 初始化时的时间，格式是 `${hour}:${minute}`，不传则默认使用当前时间（通过`moment()`）
 
 ```javascript
-// React.PropTypes.string
+// PropTypes.string
 time="11:11"
 time="11:01"
 time="1:01"
@@ -189,7 +189,7 @@ time="1:1"
 > 初始化时时间选择器的 modal 是否打开，默认为`false`
 
 ```javascript
-// React.PropTypes.bool
+// PropTypes.bool
 focused={false}
 focused={true}
 ```
@@ -199,7 +199,7 @@ focused={true}
 > 时间选择器的按钮上是否不需要 svg icon，默认为`false`
 
 ```javascript
-// React.PropTypes.bool
+// PropTypes.bool
 withoutIcon={true}
 ```
 
@@ -208,7 +208,7 @@ withoutIcon={true}
 > 配色方案，默认为`light`
 
 ```javascript
-// React.PropTypes.string
+// PropTypes.string
 colorPalette="dark"
 colorPalette="light"
 ```
@@ -218,7 +218,7 @@ colorPalette="light"
 > 12 或 24 小时制，默认为 24
 
 ```javascript
-// React.PropTypes.string or React.PropTypes.number
+// PropTypes.string or PropTypes.number
 timeMode="24"
 timeMode=24
 timeMode="12"
@@ -231,11 +231,11 @@ timeMode=12
 
 - `showTimezone`
 
-> `React.PropTypes.bool`，代表是否展示用户的时区。默认为 `false`
+> `PropTypes.bool`，代表是否展示用户的时区。默认为 `false`
 
 - `timezone`
 
-> `React.PropTypes.string`，可以通过该 props 改变用户所处的时区。默认为用户当前本地时区。
+> `PropTypes.string`，可以通过该 props 改变用户所处的时区。默认为用户当前本地时区。
 
 - `trigger`
 
@@ -301,13 +301,13 @@ timeMode=12
 
 - `onFocusChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > 当组件`focused`属性改变，也就是选择器 modal 被打开或关闭时调用
 
 - `onHourChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > 小时`hour`改变时的回调
 
@@ -319,7 +319,7 @@ onHourChange(hour) {
 
 - `onMinuteChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > 分钟`minute`被改变时的回调
 
@@ -331,7 +331,7 @@ onMinuteChange(minute) {
 
 - `onTimeChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > 小时`hour`或者分钟`minute`被改变时的回调
 
@@ -343,13 +343,13 @@ onTimeChange(time) {
 
 - `onMeridiemChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > 当 上、下午改变时触发的回调
 
 - `onTimezoneChange`
 
-`React.PropTypes.func`
+`PropTypes.func`
 
 > 当时区改变时的回调
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.13",
+    "prop-types": "^15.5.10",
     "react-bootstrap-typeahead": "^1.3.0",
     "react-transition-group": "^1.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.13",
     "prop-types": "^15.5.10",
-    "react-bootstrap-typeahead": "^1.3.0",
+    "react-bootstrap-typeahead": "^1.4.0",
     "react-transition-group": "^1.1.3"
   },
   "devDependencies": {

--- a/src/components/ClassicTheme/index.jsx
+++ b/src/components/ClassicTheme/index.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
   TIMES_12_MODE,
   TIMES_24_MODE

--- a/src/components/Common/Button/index.jsx
+++ b/src/components/Common/Button/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Button = (props) => {
   const {

--- a/src/components/MaterialTheme/TwelveHoursMode.jsx
+++ b/src/components/MaterialTheme/TwelveHoursMode.jsx
@@ -6,7 +6,8 @@ import {
   POINTER_RADIUS,
   TWELVE_HOURS,
 } from '../../utils/const_value.js';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import timeHelper from '../../utils/time';
 

--- a/src/components/MaterialTheme/TwentyFourHoursMode.jsx
+++ b/src/components/MaterialTheme/TwentyFourHoursMode.jsx
@@ -6,7 +6,8 @@ import {
   PICKER_RADIUS,
   POINTER_RADIUS,
 } from '../../utils/const_value.js';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types'
 
 import PickerDragHandler from '../Picker/PickerDragHandler';
 import pickerPointGenerator from '../Picker/PickerPointGenerator';

--- a/src/components/MaterialTheme/index.jsx
+++ b/src/components/MaterialTheme/index.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import TwelveHoursMode from './TwelveHoursMode';
 import TwentyFourHoursMode from './TwentyFourHoursMode';

--- a/src/components/OutsideClickHandler.jsx
+++ b/src/components/OutsideClickHandler.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 const propTypes = {

--- a/src/components/Picker/PickerDragHandler.jsx
+++ b/src/components/Picker/PickerDragHandler.jsx
@@ -4,7 +4,8 @@ import {
   PICKER_RADIUS,
   POINTER_RADIUS,
 } from '../../utils/const_value.js';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import ReactDOM from 'react-dom';
 import darg from '../../utils/drag';

--- a/src/components/Picker/PickerPoint.jsx
+++ b/src/components/Picker/PickerPoint.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import darg from '../../utils/drag';
 
 const propTypes = {

--- a/src/components/TimePicker.jsx
+++ b/src/components/TimePicker.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import OutsideClickHandler from './OutsideClickHandler';
 import MaterialTheme from './MaterialTheme';

--- a/src/components/Timezone/TimezonePicker.jsx
+++ b/src/components/Timezone/TimezonePicker.jsx
@@ -1,5 +1,6 @@
 import {Typeahead} from 'react-bootstrap-typeahead';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import timeHelper from '../../utils/time';
 import ICONS from '../../utils/icons';

--- a/src/components/Timezone/index.jsx
+++ b/src/components/Timezone/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 import timeHelper from '../../utils/time';


### PR DESCRIPTION
Fix the following deprecation notices : 

```
Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

React.createClass is deprecated and will be removed in version 16. Use plain JavaScript classes instead. If you're not yet ready to migrate, create-react-class is available on npm as a drop-in replacement.
```

Supersedes #52 