### PR TITLE
Move Husky from dependencies to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/ecmadao/react-times/issues"
   },
   "dependencies": {
-    "husky": "^0.14.3",
     "moment": "^2.19.1",
     "moment-timezone": "^0.5.14",
     "prop-types": "^15.5.10",
@@ -38,6 +37,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.5.0",
     "git-directory-deploy": "^1.5.1",
+    "husky": "^0.14.3",
     "in-publish": "^2.0.0",
     "mocha": "^3.3.0",
     "mocha-lcov-reporter": "^1.3.0",


### PR DESCRIPTION
As long as [husky](https://github.com/typicode/husky) is in `dependencies`, every library that uses `react-times` must use Husky for its git hook management, and not something else (e.g. [pre-commit](http://pre-commit.com/).

This pull request moves it to `dev-dependencies` instead, where it works the same but doesn't affect other packages that depend on `react-times`.