### PR TITLE
Update TwentyFourHoursMode.jsx

### DIFF
--- a/src/components/MaterialTheme/TwentyFourHoursMode.jsx
+++ b/src/components/MaterialTheme/TwentyFourHoursMode.jsx
@@ -77,7 +77,7 @@ class TwentyFourHoursMode extends React.PureComponent {
       autoMode = null,
       pointerRotate = null,
     } = options;
-    pointerRotate && this.setState({ pointerRotate });
+    Number.isInteger(pointerRotate) && this.setState({ pointerRotate });
     this.handleTimeChange(time, autoMode);
   }
 


### PR DESCRIPTION
Change line 80: 
WAS:    pointerRotate && this.setState({ pointerRotate });
BECAME:     Number.isInteger(pointerRotate) && this.setState({ pointerRotate });

Description: In some situations pointerRotate is equal to 0. If value of pointerRotate is equal to 0, it returns false. So the function, which goes after &&, will not fire. 
http://take.ms/zDyAE - initial state;
http://take.ms/Lajkm - after click on twelve or 0 hour;

As you can see: hour is changed, but the arrow position is in the previous state. My commit fixes this problem.