### PR TITLE
Check if isInteger is supported and add alternative function

### DIFF
--- a/src/components/MaterialTheme/TwentyFourHoursMode.jsx
+++ b/src/components/MaterialTheme/TwentyFourHoursMode.jsx
@@ -77,7 +77,15 @@ class TwentyFourHoursMode extends React.PureComponent {
       autoMode = null,
       pointerRotate = null,
     } = options;
-    Number.isInteger(pointerRotate) && this.setState({ pointerRotate });
+
+    const isInteger = function(num) {
+      return (num ^ 0) === +num;
+    }
+    if (Number.isInteger) {
+      Number.isInteger(pointerRotate) && this.setState({ pointerRotate: pointerRotate });
+    } else {
+      isInteger(pointerRotate) && this.setState({ pointerRotate: pointerRotate });
+    }
     this.handleTimeChange(time, autoMode);
   }
 


### PR DESCRIPTION
In 24h mode, the script uses isInteger which is not supported by IE11.
I added an alternative check for these cases.