### PR TITLE
ClassicTheme : Add support to focus on time for dropdown

### DIFF
--- a/src/components/ClassicTheme/index.jsx
+++ b/src/components/ClassicTheme/index.jsx
@@ -11,7 +11,8 @@ const propTypes = {
   clearFocus: PropTypes.func,
   colorPalette: PropTypes.string,
   handleTimeChange: PropTypes.func,
-  handleMeridiemChange: PropTypes.func
+  handleMeridiemChange: PropTypes.func,
+  focusDropdownOnTime: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -22,13 +23,30 @@ const defaultProps = {
   colorPalette: 'light',
   clearFocus: Function.prototype,
   handleTimeChange: Function.prototype,
-  handleMeridiemChange: Function.prototype
+  handleMeridiemChange: Function.prototype,
+  focusDropdownOnTime: false,
 };
 
 class ClassicTheme extends React.PureComponent {
   constructor(props) {
     super(props);
     this.handleTimeChange = this.handleTimeChange.bind(this);
+    this.handleFocusDropdownOnTime = this.handleFocusDropdownOnTime.bind(this);
+    this.dropDown = React.createRef();
+    this.dropDownActiveTime = React.createRef();
+  }
+
+  componentDidMount() {
+    this.handleFocusDropdownOnTime();
+  }
+  componentDidUpdate() {
+    this.handleFocusDropdownOnTime();
+  }
+
+  handleFocusDropdownOnTime() {
+    if (this.props.focusDropdownOnTime) {
+      this.dropDown.current.scrollTop = this.dropDownActiveTime.current.offsetTop;
+    }
   }
 
   handleTimeChange(timeData) {
@@ -63,7 +81,7 @@ class ClassicTheme extends React.PureComponent {
   }
 
   renderTimes(timeDatas) {
-    const { colorPalette } = this.props;
+    const { colorPalette, focusDropdownOnTime } = this.props;
 
     return timeDatas.map((timeData, index) => {
       const timeClass = this.checkTimeIsActive(timeData)
@@ -77,6 +95,7 @@ class ClassicTheme extends React.PureComponent {
             this.handleTimeChange(timeData);
           }}
           className={`${timeClass} ${colorPalette}`}
+          ref={this.checkTimeIsActive(timeData) ? this.dropDownActiveTime : null}
         >
           {time}
           {meridiem ? <span className="meridiem">{meridiem}</span> : null}
@@ -92,7 +111,10 @@ class ClassicTheme extends React.PureComponent {
       : timeHelper.get24ModeTimes(timeConfig);
 
     return (
-      <div className="modal_container classic_theme_container">
+      <div
+        className="modal_container classic_theme_container"
+        ref={this.dropDown}
+      >
         {this.renderTimes(timeDatas)}
       </div>
     );

--- a/src/components/TimePicker.jsx
+++ b/src/components/TimePicker.jsx
@@ -64,6 +64,7 @@ const propTypes = {
   closeOnOutsideClick: PropTypes.bool,
   timeConfig: PropTypes.object,
   disabled: PropTypes.bool,
+  focusDropdownOnTime: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -95,6 +96,7 @@ const defaultProps = {
     unit: 'minutes'
   },
   disabled: false,
+  focusDropdownOnTime: false,
 };
 
 class TimePicker extends React.PureComponent {
@@ -304,6 +306,7 @@ class TimePicker extends React.PureComponent {
       showTimezone,
       onTimezoneChange,
       timezoneIsEditable,
+      focusDropdownOnTime,
     } = this.props;
 
     if (disabled) return null;
@@ -338,6 +341,7 @@ class TimePicker extends React.PureComponent {
         handleTimeChange={this.handleTimeChange}
         handleMinuteChange={this.handleMinuteChange}
         handleMeridiemChange={this.handleMeridiemChange}
+        focusDropdownOnTime={focusDropdownOnTime}
       />
     );
   }

--- a/stories/ClassicThemePicker.js
+++ b/stories/ClassicThemePicker.js
@@ -11,6 +11,15 @@ storiesOf('Classic Theme', module)
   .addWithInfo('with default time', () => (
     <TimePickerWrapper theme="classic" defaultTime="17:00" />
   ))
+  .addWithInfo('dropdown focus on time/default time', () => (
+    <React.Fragment>
+      <TimePickerWrapper
+        theme="classic"
+        defaultTime="17:00"
+        focusDropdownOnTime
+      />
+    </React.Fragment>
+  ))
   .addWithInfo('dark color', () => (
     <TimePickerWrapper theme="classic" colorPalette="dark" />
   ))


### PR DESCRIPTION
Adding the `focusDropdownOnTime` boolean props to TimePicker (only for ClassicTheme, useless for MaterialTheme).

Enabling the focus on the `defaultTime` || `time` when the dropdown of the picker is open (useful when you use a 15 min step and your time is 23h45 😝)